### PR TITLE
Add per-group UI scaling (tied to navball) and a pending-changes indicator

### DIFF
--- a/Assets/CustomizableUI/Code/Groups/GroupCatalog.cs
+++ b/Assets/CustomizableUI/Code/Groups/GroupCatalog.cs
@@ -37,9 +37,10 @@ namespace CustomizableUI.Groups
         public static IReadOnlyCollection<string> KnownKeys => DisplayNames.Keys;
 
         /// <summary>
-        /// Groups visually/functionally tied to the navball closely enough that moving the
-        /// navball and leaving them behind would look broken -- these default to following it,
-        /// and players have to opt out via the "follow navball" toggle instead of opting in.
+        /// Groups visually/functionally tied to the navball closely enough that moving (or
+        /// resizing) the navball and leaving them behind would look broken -- these default to
+        /// both following and scaling with it, and players have to opt out via the "follow
+        /// navball" / "scale with navball" toggles instead of opting in.
         /// </summary>
         private static readonly HashSet<string> DefaultAttachToNavballKeys = new()
         {
@@ -49,6 +50,9 @@ namespace CustomizableUI.Groups
         };
 
         public static bool GetDefaultAttachToNavball(string key) => DefaultAttachToNavballKeys.Contains(key);
+
+        /// <summary>Same default set as GetDefaultAttachToNavball -- see that method's doc comment.</summary>
+        public static bool GetDefaultScaleWithNavball(string key) => DefaultAttachToNavballKeys.Contains(key);
 
         /// <summary>Exposed so GroupRegistry can warn if one of these expected keys isn't discovered at runtime.</summary>
         public static IReadOnlyCollection<string> DefaultAttachToNavballKeySet => DefaultAttachToNavballKeys;

--- a/Assets/CustomizableUI/Code/Groups/GroupHandle.cs
+++ b/Assets/CustomizableUI/Code/Groups/GroupHandle.cs
@@ -36,10 +36,37 @@ namespace CustomizableUI.Groups
         /// <summary>See GroupCatalog.GetDefaultAttachToNavball -- a handful of groups default to following the navball.</summary>
         public readonly bool DefaultAttachToNavball;
 
+        /// <summary>See GroupCatalog.GetDefaultScaleWithNavball -- a handful of groups default to scaling with the navball.</summary>
+        public readonly bool DefaultScaleWithNavball;
+
+        public const float MinScale = 0.25f;
+        public const float MaxScale = 3f;
+
         /// <summary>Manual, per-group correction applied only to the overlay's drawn position -- see OverlayCorrections.</summary>
         private readonly Vector2 _overlayCorrection;
 
         public bool AttachToNavball;
+
+        /// <summary>See GroupRegistry.RecalculateForScaleChange -- whether resizing the navball also resizes this group.</summary>
+        public bool ScaleWithNavball;
+
+        private float _scale = 1f;
+
+        /// <summary>
+        /// Uniform size multiplier, applied as Positionable's localScale directly (always
+        /// normalized to Vector3.one at discovery -- see the constructor). Unity scales a
+        /// RectTransform around its own pivot, so this resizes the group in place without
+        /// touching Position -- the pivot (and therefore the group's anchor point) doesn't move.
+        /// </summary>
+        public float Scale
+        {
+            get => _scale;
+            set
+            {
+                _scale = Mathf.Clamp(value, MinScale, MaxScale);
+                Positionable.localScale = Vector3.one * _scale;
+            }
+        }
 
         public Vector3 Position
         {
@@ -79,6 +106,16 @@ namespace CustomizableUI.Groups
             DefaultPosition = Positionable.position;
             DefaultAttachToNavball = GroupCatalog.GetDefaultAttachToNavball(key);
             AttachToNavball = DefaultAttachToNavball;
+            DefaultScaleWithNavball = GroupCatalog.GetDefaultScaleWithNavball(key);
+            ScaleWithNavball = DefaultScaleWithNavball;
+
+            // Redux doesn't always destroy/recreate these GameObjects across scene transitions
+            // (e.g. flight <-> map view) -- if this same widget survived from a previous flight
+            // session with a Scale already applied, reading its live localScale here would adopt
+            // the ALREADY-SCALED value as this session's "100%", compounding further on every
+            // re-entry instead of resetting to the widget's true natural size.
+            Positionable.localScale = Vector3.one;
+
             _isActive = true;
             IsActive = true;
         }
@@ -95,8 +132,11 @@ namespace CustomizableUI.Groups
 
         private Vector2 Pivot => RectTransform != null ? RectTransform.pivot : new Vector2(0.5f, 0.5f);
 
-        public float LeftEdge => Position.x - WidthPx * Pivot.x + _overlayCorrection.x;
-        public float TopEdge => Position.y + HeightPx * (1f - Pivot.y) + _overlayCorrection.y;
+        // _overlayCorrection was measured in raw screen pixels at Scale == 1, on a widget subtree
+        // that scales along with Positionable -- so the gap it corrects for grows/shrinks by the
+        // same factor as everything else in that subtree, and has to be scaled here to match.
+        public float LeftEdge => Position.x - WidthPx * Pivot.x + _overlayCorrection.x * Scale;
+        public float TopEdge => Position.y + HeightPx * (1f - Pivot.y) + _overlayCorrection.y * Scale;
 
         // ---- Anchor math: the pivot-space X/Y needed to put an edge/center at a screen edge/center ----
 
@@ -154,6 +194,8 @@ namespace CustomizableUI.Groups
             Position = DefaultPosition;
             IsActive = true;
             AttachToNavball = DefaultAttachToNavball;
+            ScaleWithNavball = DefaultScaleWithNavball;
+            Scale = 1f;
         }
 
         public GroupLayout ToLayout()
@@ -167,6 +209,8 @@ namespace CustomizableUI.Groups
                 PositionZ = pos.z,
                 IsActive = IsActive,
                 AttachToNavball = AttachToNavball,
+                Scale = Scale,
+                ScaleWithNavball = ScaleWithNavball,
             };
         }
 
@@ -175,6 +219,8 @@ namespace CustomizableUI.Groups
             Position = new Vector3(layout.PositionX, layout.PositionY, layout.PositionZ);
             IsActive = layout.IsActive;
             AttachToNavball = layout.AttachToNavball;
+            Scale = layout.Scale;
+            ScaleWithNavball = layout.ScaleWithNavball;
         }
     }
 }

--- a/Assets/CustomizableUI/Code/Groups/GroupLayout.cs
+++ b/Assets/CustomizableUI/Code/Groups/GroupLayout.cs
@@ -13,5 +13,7 @@ namespace CustomizableUI.Groups
         public float PositionZ;
         public bool IsActive;
         public bool AttachToNavball;
+        public float Scale = 1f;
+        public bool ScaleWithNavball;
     }
 }

--- a/Assets/CustomizableUI/Code/Groups/GroupRegistry.cs
+++ b/Assets/CustomizableUI/Code/Groups/GroupRegistry.cs
@@ -201,6 +201,56 @@ namespace CustomizableUI.Groups
             }
         }
 
+        /// <summary>
+        /// Mirrors RecalculatePositionsOfGroupsAttachedToNavball, but for size instead of
+        /// position. Scaling a RectTransform resizes it around its own pivot, not around the
+        /// navball -- so a ScaleWithNavball group left at its own Position after a scale change
+        /// would visually drift toward/away from the navball instead of shrinking/growing in
+        /// place next to it. Rescaling its offset from the navball's center by the same ratio its
+        /// own size changed by keeps it visually anchored.
+        ///
+        /// Two cases: scaling the navball itself scales every other ScaleWithNavball group (and
+        /// its distance from the navball) by the navball's own ratio; scaling a single
+        /// ScaleWithNavball group directly (leaving the navball untouched) only rescales that
+        /// group's own distance from the navball, using its own actual (post-clamp) scale ratio.
+        /// </summary>
+        public void RecalculateForScaleChange(GroupHandle changedGroup, float previousScale)
+        {
+            if (Mathf.Approximately(changedGroup.Scale, previousScale))
+                return;
+
+            var navball = Groups.Find(g => g.Key == GroupCatalog.NavballKey);
+            if (navball == null)
+                return;
+
+            if (changedGroup == navball)
+            {
+                var navballRatio = changedGroup.Scale / previousScale;
+                foreach (var group in Groups)
+                {
+                    if (group == navball || !group.ScaleWithNavball)
+                        continue;
+
+                    var groupPreviousScale = group.Scale;
+                    group.Scale *= navballRatio;
+                    RescaleOffsetFromNavball(group, navball, group.Scale / groupPreviousScale);
+                }
+                return;
+            }
+
+            if (changedGroup.ScaleWithNavball)
+            {
+                var ratio = changedGroup.Scale / previousScale;
+                RescaleOffsetFromNavball(changedGroup, navball, ratio);
+            }
+        }
+
+        private static void RescaleOffsetFromNavball(GroupHandle group, GroupHandle navball, float ratio)
+        {
+            var offsetFromNavball = group.Position - navball.Position;
+            group.Position = navball.Position + offsetFromNavball * ratio;
+        }
+
         public void ResetAllToDefault()
         {
             foreach (var group in Groups)

--- a/Assets/CustomizableUI/Code/Groups/OverlayCorrections.cs
+++ b/Assets/CustomizableUI/Code/Groups/OverlayCorrections.cs
@@ -15,9 +15,11 @@ namespace CustomizableUI.Groups
     ///
     /// These values were measured directly from screenshots -- comparing the overlay's drawn
     /// position against where the group's content actually renders, at the user's screen
-    /// resolution -- not derived from any layout data. They're an approximation and may need
-    /// further manual tuning; this is a deliberately narrow, explicit exception, not a general
-    /// heuristic (see GroupHandle/TransformExtensions for the actual geometry system).
+    /// resolution and at Scale == 1 -- not derived from any layout data. They're an approximation
+    /// and may need further manual tuning; this is a deliberately narrow, explicit exception, not
+    /// a general heuristic (see GroupHandle/TransformExtensions for the actual geometry system).
+    /// GroupHandle.LeftEdge/TopEdge multiply these by Scale, since the gap they correct for lives
+    /// in the same scaled subtree as the rest of the widget.
     /// </summary>
     public static class OverlayCorrections
     {

--- a/Assets/CustomizableUI/Code/UI/MainGuiController.cs
+++ b/Assets/CustomizableUI/Code/UI/MainGuiController.cs
@@ -60,6 +60,9 @@ namespace CustomizableUI.UI
         private const float MessageDurationSeconds = 3f;
         private bool _messageBeingShown;
 
+        private const string PendingChangesClass = "pending-changes";
+        private string _saveButtonBaseText;
+
         private VisualElement _overlay;
 
         private GroupRegistry Registry => GroupRegistry.Instance;
@@ -105,6 +108,7 @@ namespace CustomizableUI.UI
             _resetButton = _root.Q<Button>("reset-button");
             _fubarButton = _root.Q<Button>("fubar-button");
             _saveButton = _root.Q<Button>("save-button");
+            _saveButtonBaseText = _saveButton.text;
             _loadButton = _root.Q<Button>("load-button");
 
             _messageLabel = _root.Q<Label>("message-label");
@@ -131,20 +135,29 @@ namespace CustomizableUI.UI
 
             _followNavballToggle.RegisterValueChangedCallback(evt =>
             {
-                if (Registry.SelectedGroup != null)
-                    Registry.SelectedGroup.AttachToNavball = evt.newValue;
+                if (Registry.SelectedGroup == null)
+                    return;
+
+                Registry.SelectedGroup.AttachToNavball = evt.newValue;
+                MarkPendingChanges();
             });
 
             _scaleWithNavballToggle.RegisterValueChangedCallback(evt =>
             {
-                if (Registry.SelectedGroup != null)
-                    Registry.SelectedGroup.ScaleWithNavball = evt.newValue;
+                if (Registry.SelectedGroup == null)
+                    return;
+
+                Registry.SelectedGroup.ScaleWithNavball = evt.newValue;
+                MarkPendingChanges();
             });
 
             _showToggle.RegisterValueChangedCallback(evt =>
             {
-                if (Registry.SelectedGroup != null)
-                    Registry.SelectedGroup.IsActive = evt.newValue;
+                if (Registry.SelectedGroup == null)
+                    return;
+
+                Registry.SelectedGroup.IsActive = evt.newValue;
+                MarkPendingChanges();
             });
 
             _xField.RegisterValueChangedCallback(evt => MutateSelected(g => g.Position = WithX(g.Position, ParseOrKeep(evt.newValue, g.Position.x))));
@@ -162,6 +175,7 @@ namespace CustomizableUI.UI
                 var previousScale = selected.Scale;
                 selected.Scale = evt.newValue;
                 Registry.RecalculateForScaleChange(selected, previousScale);
+                MarkPendingChanges();
 
                 // Scaling changes the group's own on-screen width/height, which shifts where its
                 // edges touch the screen -- refresh everything (not just the label) so the X/Y
@@ -202,6 +216,7 @@ namespace CustomizableUI.UI
             _fubarButton.clicked += () =>
             {
                 Registry.ResetAllToDefault();
+                MarkPendingChanges();
                 ShowMessage("Layout reset to initial state.");
                 RefreshForSelection();
             };
@@ -209,12 +224,16 @@ namespace CustomizableUI.UI
             _saveButton.clicked += () =>
             {
                 SaveLoadUtility.SaveData();
+                ClearPendingChanges();
                 ShowMessage("Layout saved.");
             };
 
             _loadButton.clicked += () =>
             {
                 SaveLoadUtility.LoadData();
+                // The just-loaded layout is now exactly what's on disk, so there's nothing left
+                // to save until the next change.
+                ClearPendingChanges();
                 ShowMessage("Layout loaded.");
                 RefreshForSelection();
             };
@@ -245,6 +264,19 @@ namespace CustomizableUI.UI
             var previous = selected.Position;
             mutation(selected);
             Registry.RecalculatePositionsOfGroupsAttachedToNavball(selected, previous);
+            MarkPendingChanges();
+        }
+
+        private void MarkPendingChanges()
+        {
+            _saveButton.AddToClassList(PendingChangesClass);
+            _saveButton.text = $"{_saveButtonBaseText} *";
+        }
+
+        private void ClearPendingChanges()
+        {
+            _saveButton.RemoveFromClassList(PendingChangesClass);
+            _saveButton.text = _saveButtonBaseText;
         }
 
         // ---- Smart jump (ported from the legacy IMGUI D-pad buttons) ----

--- a/Assets/CustomizableUI/Code/UI/MainGuiController.cs
+++ b/Assets/CustomizableUI/Code/UI/MainGuiController.cs
@@ -25,6 +25,7 @@ namespace CustomizableUI.UI
         private VisualElement _body;
 
         private Toggle _followNavballToggle;
+        private Toggle _scaleWithNavballToggle;
         private Toggle _showToggle;
 
         private TextField _xField;
@@ -32,6 +33,9 @@ namespace CustomizableUI.UI
 
         private Slider _xSlider;
         private Slider _ySlider;
+
+        private Slider _scaleSlider;
+        private Label _scaleValueLabel;
 
         private Button _jumpUpButton;
         private Button _jumpDownButton;
@@ -74,6 +78,7 @@ namespace CustomizableUI.UI
             _body = _root.Q<VisualElement>("body");
 
             _followNavballToggle = _root.Q<Toggle>("follow-navball-toggle");
+            _scaleWithNavballToggle = _root.Q<Toggle>("scale-with-navball-toggle");
             _showToggle = _root.Q<Toggle>("show-toggle");
 
             _xField = _root.Q<TextField>("x-field");
@@ -83,6 +88,9 @@ namespace CustomizableUI.UI
 
             _xSlider = _root.Q<Slider>("x-slider");
             _ySlider = _root.Q<Slider>("y-slider");
+
+            _scaleSlider = _root.Q<Slider>("scale-slider");
+            _scaleValueLabel = _root.Q<Label>("scale-value-label");
 
             _jumpUpButton = _root.Q<Button>("jump-up");
             _jumpDownButton = _root.Q<Button>("jump-down");
@@ -127,6 +135,12 @@ namespace CustomizableUI.UI
                     Registry.SelectedGroup.AttachToNavball = evt.newValue;
             });
 
+            _scaleWithNavballToggle.RegisterValueChangedCallback(evt =>
+            {
+                if (Registry.SelectedGroup != null)
+                    Registry.SelectedGroup.ScaleWithNavball = evt.newValue;
+            });
+
             _showToggle.RegisterValueChangedCallback(evt =>
             {
                 if (Registry.SelectedGroup != null)
@@ -138,6 +152,22 @@ namespace CustomizableUI.UI
 
             _xSlider.RegisterValueChangedCallback(evt => MutateSelected(g => g.Position = WithX(g.Position, evt.newValue)));
             _ySlider.RegisterValueChangedCallback(evt => MutateSelected(g => g.Position = WithY(g.Position, evt.newValue)));
+
+            _scaleSlider.RegisterValueChangedCallback(evt =>
+            {
+                var selected = Registry.SelectedGroup;
+                if (selected == null)
+                    return;
+
+                var previousScale = selected.Scale;
+                selected.Scale = evt.newValue;
+                Registry.RecalculateForScaleChange(selected, previousScale);
+
+                // Scaling changes the group's own on-screen width/height, which shifts where its
+                // edges touch the screen -- refresh everything (not just the label) so the X/Y
+                // sliders' ranges stay in sync and still let it travel all the way to the edge.
+                RefreshForSelection();
+            });
 
             _jumpUpButton.clicked += () => MutateSelected(JumpUp);
             _jumpDownButton.clicked += () => MutateSelected(JumpDown);
@@ -155,7 +185,16 @@ namespace CustomizableUI.UI
                 if (selected == null)
                     return;
 
+                var previousScale = selected.Scale;
                 MutateSelected(g => g.ResetToDefault());
+
+                // Only cascade when the navball itself was reset -- ResetToDefault() already put
+                // `selected` back at its own correct absolute Position, so rescaling its offset
+                // from the navball afterward (what this does for a directly-scaled, non-navball
+                // group) would incorrectly nudge it away from that just-restored default.
+                if (selected.Key == GroupCatalog.NavballKey)
+                    Registry.RecalculateForScaleChange(selected, previousScale);
+
                 ShowMessage($"Group {selected.DisplayName} reset.");
                 RefreshForSelection();
             };
@@ -265,6 +304,8 @@ namespace CustomizableUI.UI
 
             _followNavballToggle.SetValueWithoutNotify(selected.AttachToNavball);
             _followNavballToggle.SetEnabled(selected.Key != GroupCatalog.NavballKey);
+            _scaleWithNavballToggle.SetValueWithoutNotify(selected.ScaleWithNavball);
+            _scaleWithNavballToggle.SetEnabled(selected.Key != GroupCatalog.NavballKey);
             _showToggle.SetValueWithoutNotify(selected.IsActive);
 
             var pos = selected.Position;
@@ -275,7 +316,15 @@ namespace CustomizableUI.UI
             SetSliderRangeAndValue(_ySlider, selected.VerticalLowerBottom, selected.VerticalUpperTop, pos.y);
 
             RefreshPositionFields(selected);
+
+            // Scale's range is fixed (GroupHandle.MinScale/MaxScale), set once in UXML, so unlike
+            // the position sliders this never needs the widen/narrow dance -- just the value.
+            _scaleSlider.SetValueWithoutNotify(selected.Scale);
+            RefreshScaleLabel(selected);
         }
+
+        private void RefreshScaleLabel(GroupHandle selected) =>
+            _scaleValueLabel.text = $"{Mathf.Round(selected.Scale * 100f):F0}%";
 
         /// <summary>
         /// Changes a Slider's range and value together without ever letting `.value` sit outside

--- a/Assets/CustomizableUI/UI/CustomizableUI.uss
+++ b/Assets/CustomizableUI/UI/CustomizableUI.uss
@@ -393,7 +393,42 @@
     padding-left: 40px;
 }
 
-.pending-changes {
+#save-button.pending-changes {
+    border-top-color: var(--yellowish);
+    border-right-color: var(--yellowish);
+    border-bottom-color: var(--yellowish);
+    border-left-color: var(--yellowish);
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+    color: var(--yellowish);
+    -unity-background-image-tint-color: var(--yellowish);
+    -unity-font-style: italic;
+}
+
+#save-button.pending-changes:hover {
+    border-left-color: var(--background-lightgray-4-translucent);
+    border-right-color: var(--background-lightgray-4-translucent);
+    border-top-color: var(--background-lightgray-4-translucent);
+    border-bottom-color: var(--background-lightgray-4-translucent);
+    background-color: var(--black-1-translucent);
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
+}
+
+#save-button.pending-changes:active {
+    border-left-color: var(--border-active-green);
+    border-right-color: var(--border-active-green);
+    border-top-color: var(--border-active-green);
+    border-bottom-color: var(--border-active-green);
+    background-color: var(--black-1-translucent);
+    border-top-width: 1px;
+    border-right-width: 1px;
+    border-bottom-width: 1px;
+    border-left-width: 1px;
 }
 
 .load-layout {

--- a/Assets/CustomizableUI/UI/CustomizableUI.uss
+++ b/Assets/CustomizableUI/UI/CustomizableUI.uss
@@ -3,6 +3,8 @@
     --background-gray-1-translucent: rgba(33, 39, 46, 0.5);
     --black-1: rgb(17, 20, 26);
     --black-1-translucent: rgba(17, 20, 26, 0.5);
+    --yellowish: rgb(237, 208, 147);
+    --yellowish-translucent: rgba(237, 208, 147, 0.1);
     --background-gray-2: rgb(28, 34, 42);
     --background-gray-2-translucent: rgba(28, 34, 42, 0.5);
     --background-gray-3: rgb(46, 53, 64);
@@ -389,6 +391,9 @@
     background-position-x: left 65px;
     -unity-background-image-tint-color: rgb(242, 242, 242);
     padding-left: 40px;
+}
+
+.pending-changes {
 }
 
 .load-layout {

--- a/Assets/CustomizableUI/UI/CustomizableUI.uxml
+++ b/Assets/CustomizableUI/UI/CustomizableUI.uxml
@@ -90,7 +90,7 @@
         </ui:VisualElement>
         <ui:VisualElement name="footer" class="footer">
             <ui:VisualElement name="save-load-row" style="flex-direction: row; justify-content: space-around; width: 100%; padding-top: 5px;">
-                <ui:Button text="Save Layout" display-tooltip-when-elided="true" name="save-button" class="save-layout pending-changes"/>
+                <ui:Button text="Save Layout" display-tooltip-when-elided="true" name="save-button" class="save-layout" style="-unity-text-align: middle-left; padding-left: 95px;"/>
                 <ui:Button text="Load Layout" display-tooltip-when-elided="true" name="load-button" class="load-layout"/>
             </ui:VisualElement>
             <ui:Label display-tooltip-when-elided="true" name="message-label" text="Layout reset to initial state." class="notification" style="background-color: rgba(64, 245, 0, 0.4); top: 55px;"/>

--- a/Assets/CustomizableUI/UI/CustomizableUI.uxml
+++ b/Assets/CustomizableUI/UI/CustomizableUI.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/CustomizableUI/UI/CustomizableUI.uss?fileID=7433441132597879392&amp;guid=cb912fd60eae1904fa0e7e1512e9b4fa&amp;type=3#CustomizableUI"/>
-    <ui:VisualElement name="root" class="root" style="height: 486px;">
+    <ui:VisualElement name="root" class="root" style="height: 526px;">
         <ui:VisualElement name="header" class="header">
             <ui:VisualElement name="title__container" class="title__container">
                 <ui:VisualElement name="icon" class="icon"/>
@@ -27,10 +27,19 @@
                 <ui:Toggle label="Show UI Group" name="show-toggle" class="led-toggle"/>
                 <ui:VisualElement style="flex-grow: 1; width: 20px;"/>
                 <ui:Toggle label="Follow Navball" name="follow-navball-toggle" class="led-toggle"/>
+                <ui:VisualElement style="flex-grow: 1; width: 20px;"/>
+                <ui:Toggle label="Scale With Navball" name="scale-with-navball-toggle" class="led-toggle"/>
+            </ui:VisualElement>
+            <ui:VisualElement name="scale-row" class="row scale-row" style="flex-direction: row; align-items: center; width: 93%; margin-top: 10px;">
+                <ui:Label text="Scale" name="scale-label" class="field-label" style="margin-right: 8px;"/>
+                <ui:Slider name="scale-slider" low-value="0.25" high-value="3" value="1" class="position-slider" style="min-width: 40%;"/>
+                <ui:Label text="100%" name="scale-value-label" class="field-label" style="margin-left: 8px; min-width: 40px; -unity-text-align: middle-right;"/>
             </ui:VisualElement>
             <ui:VisualElement name="position-row" class="position-row" style="flex-direction: row;">
                 <ui:VisualElement name="position-left-column" style="flex-grow: 1; width: 50%;">
                     <ui:VisualElement name="x-container" style="flex-direction: row; align-items: center; justify-content: flex-end; padding-right: 10px;">
+                        <ui:Label text="Position" style="width: 75px;"/>
+                        <ui:VisualElement style="flex-grow: 1;"/>
                         <ui:Label text="X:" name="x-label" class="field-label"/>
                         <ui:TextField name="x-field" class="position-field"/>
                     </ui:VisualElement>
@@ -51,7 +60,9 @@
                 </ui:VisualElement>
             </ui:VisualElement>
             <ui:VisualElement name="position-adjustments" style="flex-direction: row; width: 100%; margin-top: 10px;">
-                <ui:VisualElement name="fine-adjustments-column" style="width: 80%; flex-direction: row; justify-content: center;">
+                <ui:VisualElement name="fine-adjustments-column" style="width: 80%; flex-direction: row; justify-content: flex-start; padding-left: 20px;">
+                    <ui:Label text="Fine-tune" style="width: 75px;"/>
+                    <ui:VisualElement style="width: 45px;"/>
                     <ui:VisualElement name="fine-buttons-container-1" class="fine-buttons-container" style="flex-grow: 1;">
                         <ui:Button text="" display-tooltip-when-elided="true" name="jump-left" class="position-button" style="background-image: url(&quot;project://database/Assets/CustomizableUI/Copied/assets/images/double-left.png?fileID=2800000&amp;guid=cbe1ddb15c1b3074a97d777212854ec9&amp;type=3#double-left&quot;);"/>
                     </ui:VisualElement>
@@ -79,7 +90,7 @@
         </ui:VisualElement>
         <ui:VisualElement name="footer" class="footer">
             <ui:VisualElement name="save-load-row" style="flex-direction: row; justify-content: space-around; width: 100%; padding-top: 5px;">
-                <ui:Button text="Save Layout&#10;" display-tooltip-when-elided="true" name="save-button" class="save-layout"/>
+                <ui:Button text="Save Layout" display-tooltip-when-elided="true" name="save-button" class="save-layout pending-changes"/>
                 <ui:Button text="Load Layout" display-tooltip-when-elided="true" name="load-button" class="load-layout"/>
             </ui:VisualElement>
             <ui:Label display-tooltip-when-elided="true" name="message-label" text="Layout reset to initial state." class="notification" style="background-color: rgba(64, 245, 0, 0.4); top: 55px;"/>


### PR DESCRIPTION
## Summary
- Add per-group UI scaling: a Scale slider (25%-300%) on `GroupHandle`, persisted via `GroupLayout`/`SaveLoadUtility`
- Add a `ScaleWithNavball` toggle (mirrors `AttachToNavball`) so a group's size and distance from the navball scale together with it, via `GroupRegistry.RecalculateForScaleChange` -- handles both scaling the navball itself (cascades to every `ScaleWithNavball` group) and scaling an attached group directly (rescales just its own offset so it doesn't drift from the navball as it resizes)
- Fix position sliders staying at pre-scale bounds after a group was resized, blocking movement to the newly-reachable screen edges
- Fix resetting the navball not cascading the scale-with-navball rescale to attached groups, unlike its position-follow counterpart
- Fix the overlay highlight box drifting off scaled groups that use `OverlayCorrections`' manual pixel offsets (VERTICAL.SPEED, ATMOSPHERIC.INDICATOR, THROTTLE) -- those offsets were measured at Scale == 1 and needed to scale with the rest of the widget
- Fix scale compounding across flight-scene re-entries (e.g. via map view) by forcing `Positionable.localScale` back to `Vector3.one` at discovery time, instead of trusting a possibly-already-scaled live transform as the baseline
- Add a pending-changes indicator on the Save Layout button -- any unsaved edit (position/scale, show/hide, follow-navball, scale-with-navball, reset, FUBAR) applies a `pending-changes` USS class and appends " *" to the label; Save/Load clears both

## Test plan
- [ ] Scale an individual group up/down, confirm the X/Y position sliders let it reach the true screen edges at the new size
- [ ] Scale the navball with a `ScaleWithNavball` group selected elsewhere, confirm that group scales and stays visually anchored to the navball
- [ ] Scale a `ScaleWithNavball` group directly, confirm it doesn't drift away from the navball
- [ ] Scale up the navball, then select it and press Reset -- confirm attached groups scale back down too
- [ ] Select VERTICAL.SPEED / ATMOSPHERIC.INDICATOR / THROTTLE, scale them, confirm the overlay highlight box tracks the actual widget
- [ ] Set a group's scale, enter map view, return to flight view, confirm the scale did not compound
- [ ] Move/scale/hide a group and confirm the Save Layout button shows the pending-changes styling and " *"; confirm Save and Load both clear it

🤖 Generated with [Claude Code](https://claude.com/claude-code)